### PR TITLE
ci: ensure small file sizes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,8 @@ jobs:
           yarn --pure-lockfile
       - name: Lint
         run: yarn lint:ci
+      - name: Check file sizes
+        run: ./scripts/check-svg-sizes.sh
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "foundry run eslint . --ext .ts,.tsx,.js,.jsx",
     "lint:fix": "yarn lint --fix",
     "lint:ci": "yarn lint --format junit -o __reports__/eslint-results.xml",
+    "check-sizes": "./scripts/check-svg-sizes.sh",
     "prerelease": "yarn build && cp web/v1/* .",
     "release": "foundry run semantic-release",
     "postrelease": "rm -f *.svg"

--- a/scripts/check-svg-sizes.sh
+++ b/scripts/check-svg-sizes.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Reports all SVGs in the /web folder that exceed the size limit.
+
+size_limit=15
+offenders=$(find ./web -type f -name "*.svg" -size +${size_limit}k ! -path '*flags*')
+
+if [ ! -z "$offenders" ]
+then
+  offender_array=()
+
+  while read line; do
+    offender_array+=("$line")
+  done <<< "$offenders"
+
+  file_count=${#offender_array[@]} # $(echo -n "$offenders" | grep -c '^')
+
+  echo "The following $file_count SVG files exceed ${size_limit}kb and need to be optimized:"
+  echo "Size | Path"
+
+  for file_path in "${offender_array[@]}"
+  do
+    file_size=$(du -h "$file_path" | cut -f1)
+    echo "$file_size | $file_path"
+  done
+
+  exit 1;
+else
+  echo "No SVG files exceed ${size_limit}kb. That's great!"
+
+  exit 0;
+fi


### PR DESCRIPTION
## Purpose

SVGs can be surprisingly heavy, e.g. when they embed raster images. To avoid performance issues, SVGs should not be larger than 15KB. 

## Approach and changes

- add bash script that checks file sizes in CI

## Definition of done

- [x] Development completed
- [x] Reviewers assigned
